### PR TITLE
Fix idlelog doing wrong combat check

### DIFF
--- a/src/main/java/com/rs/game/player/Player.java
+++ b/src/main/java/com/rs/game/player/Player.java
@@ -1035,7 +1035,7 @@ public class Player extends Entity {
 				if (!(getActionManager().getAction() instanceof PlayerCombat)) {
 					logout(true);
 				} else {
-					if (!(((PlayerCombat) getActionManager().getAction()).getTarget() instanceof Player)) {
+					if (!inCombat(10000)) {
 						idleLog();
 					}
 				}


### PR DESCRIPTION
How I know it works without testing -

A) You can idle log out in combat
B) You do not get a message saying you can't log out for 10 seconds when you do

Because of A), this function is probably the one causing idle logout
Because of B), it's not running the first branch (`logout(true);`)
Because of it's clearly doing the wrong check in B), and the check in A) works, I've reused the combat check in `logout` here

*This change is completely licensed to Trent and free for him to use in whatever way he wants. I have zero ownership over this change