### PR TITLE
Jawarriors fix for dungeoneering rooms not loading.

### DIFF
--- a/src/main/java/com/rs/game/player/content/skills/dungeoneering/DungeonManager.java
+++ b/src/main/java/com/rs/game/player/content/skills/dungeoneering/DungeonManager.java
@@ -284,8 +284,6 @@ public class DungeonManager {
 		region.copy2x2ChunkSquare(chunkOffX, chunkOffY, room.getChunkX(party.getComplexity()), room.getChunkY(party.getFloorType()), room.getRotation(), new int[] { 0, 1 }, () -> {
 			int regionId = region.getRegionId();
 			for (Player player : party.getTeam()) {
-				if (!player.getMapRegionsIds().contains(regionId))
-					continue;
 				player.setForceNextMapLoadRefresh(true);
 				player.loadMapRegions();
 			}


### PR DESCRIPTION
Fix for when players open a door to a room in a different region than they are currently standing in.