### PR TITLE
A potential system for making music more like the real game

### DIFF
--- a/data/music.json
+++ b/data/music.json
@@ -1551,13 +1551,13 @@
     ]
   },
   {
-    "name": "",
+    "name": "Wally vs Delrith",
     "hint": "somewhere.",
     "id": 195,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Player vs Delrith",
     "hint": "somewhere.",
     "id": 196,
     "regionIds": []
@@ -2778,7 +2778,7 @@
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Elvarg's Theme",
     "hint": "somewhere.",
     "id": 360,
     "regionIds": []
@@ -3117,7 +3117,7 @@
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "To Crandor/Keldagrim! Theme, Dragon Slayer, Giant Dwarf",
     "hint": "somewhere.",
     "id": 406,
     "regionIds": []
@@ -4772,61 +4772,61 @@
     ]
   },
   {
-    "name": "",
+    "name": "Ghostly piper",
     "hint": "somewhere.",
     "id": 656,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Violin Musician",
     "hint": "somewhere.",
     "id": 657,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Accordian musician",
     "hint": "somewhere.",
     "id": 658,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Elven Flute",
     "hint": "somewhere.",
     "id": 659,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Double Flute Musician Arabian",
     "hint": "somewhere.",
     "id": 660,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Lute Musician Harmony, Regular",
     "hint": "somewhere.",
     "id": 661,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Lyre Musician Relleka",
     "hint": "somewhere.",
     "id": 662,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Flute Musician Arabian",
     "hint": "somewhere.",
     "id": 663,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Drunken Musician lyre",
     "hint": "somewhere.",
     "id": 664,
     "regionIds": []
   },
   {
-    "name": "",
+    "name": "Drum musician",
     "hint": "somewhere.",
     "id": 665,
     "regionIds": []

--- a/data/music.json
+++ b/data/music.json
@@ -3392,7 +3392,9 @@
     "name": "Venomous",
     "hint": "at the Scorpion Pit in the Wilderness.",
     "id": 450,
-    "regionIds": []
+    "regionIds": [
+      12867
+    ]
   },
   {
     "name": "Tune from the Dune",
@@ -3408,7 +3410,9 @@
     "name": "Copris Lunaris",
     "hint": "during Dealing with Scabaras.",
     "id": 452,
-    "regionIds": []
+    "regionIds": [
+      13099
+    ]
   },
   {
     "name": "Jungle Hunt",
@@ -3431,19 +3435,25 @@
     "name": "Scarabaeoidea",
     "hint": "during Dealing with Scabaras.",
     "id": 455,
-    "regionIds": []
+    "regionIds": [
+      13099
+    ]
   },
   {
     "name": "Animal Apogee",
     "hint": "during Wolf Whistle.",
     "id": 456,
-    "regionIds": []
+    "regionIds": [
+      11573
+    ]
   },
   {
     "name": "Scape Summon",
-    "hint": "automatically.",
+    "hint": "automatically. Taverly",
     "id": 457,
-    "regionIds": []
+    "regionIds": [
+      11573
+    ]
   },
   {
     "name": "",
@@ -3496,7 +3506,10 @@
     "name": "The Genie",
     "hint": "at the genie's cave west of Nardah.",
     "id": 464,
-    "regionIds": []
+    "regionIds": [
+      13101,
+      13357
+    ]
   },
   {
     "name": "Desert Heat",
@@ -3996,7 +4009,9 @@
     "name": "Under the Sand",
     "hint": "during Smoking Kills.",
     "id": 539,
-    "regionIds": []
+    "regionIds": [
+      13358
+    ]
   },
   {
     "name": "Desert Smoke",
@@ -5100,7 +5115,9 @@
     "name": "Final Destination",
     "hint": "in Kuradal's Slayer Dungeon.",
     "id": 710,
-    "regionIds": []
+    "regionIds": [
+      6482
+    ]
   },
   {
     "name": "",
@@ -5278,7 +5295,7 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 740,
     "regionIds": []
   },
@@ -5302,13 +5319,13 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 744,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 745,
     "regionIds": []
   },
@@ -5332,25 +5349,25 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 749,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 750,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 751,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 752,
     "regionIds": []
   },
@@ -5362,13 +5379,13 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 754,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 755,
     "regionIds": []
   },
@@ -5386,7 +5403,7 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 758,
     "regionIds": []
   },
@@ -5398,7 +5415,7 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 760,
     "regionIds": []
   },
@@ -5410,31 +5427,31 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 762,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 763,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 764,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 765,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 766,
     "regionIds": []
   },
@@ -5458,7 +5475,7 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Floor Complete, Dungeoneering",
     "id": 770,
     "regionIds": []
   },
@@ -5470,19 +5487,19 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 772,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 773,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 774,
     "regionIds": []
   },
@@ -5566,13 +5583,13 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 788,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 789,
     "regionIds": []
   },
@@ -5584,19 +5601,19 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 791,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 792,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 793,
     "regionIds": []
   },
@@ -5608,25 +5625,25 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 795,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 796,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 797,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 798,
     "regionIds": []
   },
@@ -5638,7 +5655,7 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 800,
     "regionIds": []
   },
@@ -5656,7 +5673,7 @@
   },
   {
     "name": "Born to Do This",
-    "hint": "during Dungeoneering.",
+    "hint": "Daemonheim.",
     "id": 803,
     "regionIds": [
       13624,
@@ -5671,25 +5688,25 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 804,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 805,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 806,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 807,
     "regionIds": []
   },
@@ -5701,7 +5718,7 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 809,
     "regionIds": []
   },
@@ -5719,13 +5736,13 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 812,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 813,
     "regionIds": []
   },
@@ -5767,13 +5784,24 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Safe room, Ambient dungeoneering",
     "id": 822,
-    "regionIds": []
+    "regionIds": [
+      343,
+      342,
+      341,
+      340,
+      339,
+      338,
+      337,
+      336,
+      335,
+      334
+    ]
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 823,
     "regionIds": []
   },
@@ -5785,13 +5813,13 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 825,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 826,
     "regionIds": []
   },
@@ -5803,19 +5831,19 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 828,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 829,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 830,
     "regionIds": []
   },
@@ -5845,13 +5873,13 @@
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 835,
     "regionIds": []
   },
   {
     "name": "",
-    "hint": "somewhere.",
+    "hint": "Ambient dungeoneering",
     "id": 836,
     "regionIds": []
   },
@@ -5865,25 +5893,45 @@
     "name": "Thieves' Guild III",
     "hint": "in the Thieves' Guild.",
     "id": 838,
-    "regionIds": []
+    "regionIds": [
+      19036,
+      19034,
+      18522,
+      18524
+    ]
   },
   {
     "name": "Thieves' Guild II",
     "hint": "in the Thieves' Guild.",
     "id": 839,
-    "regionIds": []
+    "regionIds": [
+      19036,
+      19034,
+      18522,
+      18524
+    ]
   },
   {
     "name": "Thieves' Guild IV",
     "hint": "in the Thieves' Guild.",
     "id": 840,
-    "regionIds": []
+    "regionIds": [
+      19036,
+      19034,
+      18522,
+      18524
+    ]
   },
   {
     "name": "Thieves' Guild I",
     "hint": "in the Thieves' Guild.",
     "id": 842,
-    "regionIds": []
+    "regionIds": [
+      19036,
+      19034,
+      18522,
+      18524
+    ]
   },
   {
     "name": "Root Canal",
@@ -7186,13 +7234,21 @@
     "name": "Daemonheim Entrance",
     "hint": "at the entrance to Daemonheim.",
     "id": 1089,
-    "regionIds": []
+    "regionIds": [
+      13624,
+      13625,
+      13881
+    ]
   },
   {
     "name": "Daemonheim Fremenniks",
     "hint": "at the entrance to Daemonheim.",
     "id": 1090,
-    "regionIds": []
+    "regionIds": [
+      13624,
+      13625,
+      13881
+    ]
   },
   {
     "name": "Runeward",

--- a/data/musicGenre.json
+++ b/data/musicGenre.json
@@ -1,0 +1,356 @@
+[
+  {
+    "genre": "Desert",
+    "comment": "isdone",
+    "regionIds": [
+      13107,
+      13106,
+      13105,
+      13104,
+      12848,
+      13360,
+      13616,
+      13872,
+      12591,
+      12847,
+      13103,
+      13359,
+      13615,
+      13871,
+      12590,
+      12846,
+      13102,
+      13358,
+      13614,
+      13870,
+      12589,
+      12845,
+      13101,
+      13357,
+      13613,
+      13869,
+      14126,
+      14125,
+      12588,
+      12844,
+      13100,
+      13356,
+      13612,
+      12587,
+      12843,
+      13099,
+      13355
+    ],
+    "songs": [
+      36,
+      50,
+      69,
+      79,
+      123,
+      124,
+      168,
+      174,
+      263,
+      267,
+      383,
+      351,
+      352,
+      359,
+      377,
+      383,
+      387,
+      447,
+      451,
+      452,
+      455,
+      464,
+      465,
+      505,
+      539,
+      540,
+      666
+    ]
+  },
+  {
+    "genre": "Swamp",
+    "comment": "13611 is Just southern desert",
+    "regionIds": [
+      13611
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Pirate",
+    "comment": "https://runescape.fandom.com/wiki/Music?oldid=5927398",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Morytania",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Dungeons",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Gnome",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Varrock",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Ardougne",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Wilderness",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Isafdar",
+    "comment": "Elven, Isafdar, Tirannwn",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Ogre",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Lumbridge Draynor",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "God Wars Dungeon",
+    "comment": "",
+    "regionIds": [
+
+    ],
+    "songs": [
+      0
+    ]
+  },
+  {
+    "genre": "Daemonheim, Dungeoneering",
+    "comment": "isdone",
+    "regionIds": [
+      13627,
+      13883,
+      13626,
+      13882,
+      13625,
+      13624,
+      13881
+    ],
+    "songs": [
+      803,
+      1089,
+      1090
+    ]
+  },
+  {
+    "genre": "Ambient music, Dungeoneering",
+    "comment": "Appended to dugeoneering genres",
+    "regionIds": [],
+    "songs": [
+      740,
+      744,
+      745,
+      749,
+      750,
+      751,
+      752,
+      754,
+      755,
+      758,
+      760,
+      762,
+      763,
+      764,
+      765,
+      766,
+      772,
+      773,
+      774,
+      788,
+      789,
+      791,
+      792,
+      793,
+      795,
+      796,
+      797,
+      798,
+      800,
+      804,
+      805,
+      806,
+      807,
+      809,
+      812,
+      813,
+      823,
+      825,
+      826,
+      828,
+      829,
+      830,
+      835,
+      836
+    ]
+  },
+  {
+    "genre": "Safe Room, Dungeoneering",
+    "comment": "Called when in dynamic safe room, appended to ambient",
+    "regionIds": [],
+    "songs": [
+      822
+    ]
+  },
+  {
+    "genre": "Frozen floors, Dungeoneering",
+    "comment": "called in frozen rooms, appended to ambient",
+    "regionIds": [],
+    "songs": [
+      808,
+      810,
+      811,
+      824,
+      827,
+      831,
+      832,
+      833,
+      834,
+      837
+    ]
+  },
+  {
+    "genre": "Abandoned floors, Dungeoneering",
+    "comment": "called in abandoned rooms, appended to ambient",
+    "regionIds": [],
+    "songs": [
+      771,
+      775,
+      779,
+      780,
+      781,
+      790,
+      794,
+      799,
+      801,
+      802
+    ]
+  },
+  {
+    "genre": "Furnished floors, Dungeoneering",
+    "comment": "called in furnished rooms, appended to ambient",
+    "regionIds": [],
+    "songs": [
+      739,
+      741,
+      742,
+      747,
+      748,
+      753,
+      756,
+      757,
+      761,
+      769
+    ]
+  },
+  {
+    "genre": "Occult floors, Dungeoneering",
+    "comment": "called in occult rooms, appended to ambient",
+    "regionIds": [],
+    "songs": [
+      860,
+      864,
+      870,
+      872,
+      873,
+      880,
+      882,
+      885,
+      886,
+      889
+    ]
+  },
+  {
+    "genre": "Warped floors, Dungeoneering",
+    "comment": "called in warped rooms, appended to ambient",
+    "regionIds": [],
+    "songs": [
+      911,
+      914,
+      917,
+      920,
+      925,
+      927,
+      930,
+      936,
+      938,
+      939
+    ]
+  }
+]

--- a/data/npcs/spawns/rsSpawns.json
+++ b/data/npcs/spawns/rsSpawns.json
@@ -118326,8 +118326,8 @@
   {
     "tile": {
       "plane": 0,
-      "x": 3291,
-      "y": 3214
+      "x": 3292,
+      "y": 3212
     },
     "comment": "Musician",
     "npcId": 8707
@@ -118375,7 +118375,7 @@
       "y": 3524
     },
     "comment": "Musician",
-    "npcId": 8721
+    "npcId": 8713
   },
   {
     "tile": {

--- a/src/main/java/com/rs/game/Entity.java
+++ b/src/main/java/com/rs/game/Entity.java
@@ -693,6 +693,10 @@ public abstract class Entity extends WorldTile {
             case 14858:
             case 14883:
             case 2859:
+            case 8709://Desert musician
+            case 8715://Drunken musician
+            case 8723://Elf musician
+            case 8712://Goblin musician
 				return true;
 			}
             switch(npc.getName()) {
@@ -703,6 +707,7 @@ public abstract class Entity extends WorldTile {
                 case "Cavefish shoal":
                 case "Rocktail shoal":
                 case "Musician":
+                case "Ghostly piper":
                     return true;
             }
 		}

--- a/src/main/java/com/rs/game/World.java
+++ b/src/main/java/com/rs/game/World.java
@@ -68,6 +68,8 @@ import com.rs.plugin.events.NPCInstanceEvent;
 import com.rs.utils.AntiFlood;
 import com.rs.utils.Areas;
 import com.rs.utils.Ticks;
+import com.rs.utils.music.Genre;
+import com.rs.utils.music.Music;
 import com.rs.utils.shop.ShopsHandler;
 
 
@@ -312,9 +314,14 @@ public final class World {
 					getRegion(entity.getLastRegionId()).removePlayerIndex(entity.getIndex());
 				Region region = getRegion(regionId);
 				region.addPlayerIndex(entity.getIndex());
-				int musicId = region.getMusicId();
-				if (musicId != -1)
-					player.getMusicsManager().checkMusic(musicId);
+                int musicId = region.getMusicId();
+                if (musicId != -1)//if should play random song on enter region
+                    if(Music.getGenre(regionId) == null || player.getMusicsManager().getPlayingGenre() == null
+                            || !player.getMusicsManager().isUnlocked(musicId) || !player.getMusicsManager().getPlayingGenre().matches(Music.getGenre(regionId)))
+                        player.getMusicsManager().checkMusic(musicId);
+
+
+
 				player.getControllerManager().moved();
 				if (player.hasStarted())
 					checkControllersAtMove(player);

--- a/src/main/java/com/rs/game/player/Player.java
+++ b/src/main/java/com/rs/game/player/Player.java
@@ -1062,9 +1062,8 @@ public class Player extends Entity {
 		
 		if (getTickCounter() % FarmPatch.FARMING_TICK == 0)
 			tickFarming();
-		
-		if (musicsManager.musicEnded())
-			musicsManager.replayMusic();
+
+        processMusic();
 		
 		if (inCombat() || isAttacking()) {
 			for (int i = 0;i < Equipment.SIZE;i++) {
@@ -1125,6 +1124,19 @@ public class Player extends Entity {
 		prayer.processPrayer();
 		controllerManager.process();
 	}
+
+    private void processMusic() {
+        if (musicsManager.musicEnded() && !getTempAttribs().getB("MUSIC_BREAK")) {
+            getTempAttribs().setB("MUSIC_BREAK", true);
+            WorldTasksManager.schedule(new WorldTask() {
+                @Override
+                public void run() {
+                    musicsManager.replayMusic();
+                    getTempAttribs().setB("MUSIC_BREAK", false);
+                }
+            }, Utils.randomInclusive(10, 30));
+        }
+    }
 	
 	public void restoreTick(int skill, int restore) {
 		int currentLevel = getSkills().getLevel(skill);

--- a/src/main/java/com/rs/game/player/actions/RestMusician.java
+++ b/src/main/java/com/rs/game/player/actions/RestMusician.java
@@ -1,0 +1,113 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  Copyright © 2021 Trenton Kress
+//  This file is part of project: Darkan
+//
+package com.rs.game.player.actions;
+
+import com.rs.game.player.Player;
+import com.rs.lib.game.Animation;
+import com.rs.lib.util.Utils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class RestMusician extends Action {
+
+	private static int[][] REST_DEFS = { { 5713, 1549, 5748 }, { 11786, 1550, 11788 }, { 5713, 1551, 2921 } // TODO
+																											// First
+																											// emote
+
+	};
+
+    private Map<Integer, Integer> musicListing = Map.ofEntries(
+            Map.entry(5439, 661),//lute
+            Map.entry(8705, 661),//lute
+            Map.entry(8698, 657),//violin
+            Map.entry(29, 661),//lute
+            Map.entry(8709, 660),//double flute
+            Map.entry(8715, 664),//drunk
+            Map.entry(8723, 659),//elven
+            Map.entry(8712, 665),//drum
+            Map.entry(8702, 661),//lute
+            Map.entry(8706, 657),//violin
+            Map.entry(8716, 662),//lyre
+            Map.entry(8703, 661), //lute
+            Map.entry(8704, 657),//violin
+            Map.entry(8717, 662),//lyre
+            Map.entry(8718, 662),//lyre
+            Map.entry(5442, 661),//lute
+            Map.entry(30, 661),//lute
+            Map.entry(8699, 657),//violin
+            Map.entry(3463, 661),//lute
+            Map.entry(8708, 660),//double flute
+            Map.entry(8707, 660),//double flute
+            Map.entry(8701, 657),//violin
+            Map.entry(8700, 657),//violin
+            Map.entry(8713, 656)//ghost
+    );
+
+    private int musicId;
+	private int index;
+
+    public RestMusician(int musicianId) {
+        if(musicListing.containsKey(musicianId))
+            musicId = musicListing.get(musicianId);
+        else
+            musicId = -1;
+    }
+
+	@Override
+	public boolean start(Player player) {
+		if (!process(player))
+			return false;
+		index = Utils.random(REST_DEFS.length);
+		player.setResting(true);
+		player.setNextAnimation(new Animation(REST_DEFS[index][0]));
+		player.getAppearance().setBAS(REST_DEFS[index][1]);
+		return true;
+	}
+
+	@Override
+	public boolean process(Player player) {
+        if(musicId != -1 && !player.getMusicsManager().isPlaying(musicId))
+            player.getPackets().sendMusic(musicId);
+		if (player.getPoison().isPoisoned()) {
+			player.sendMessage("You can't rest while you're poisoned.");
+			return false;
+		}
+		if (player.inCombat(10000)) {
+			player.sendMessage("You can't rest until 10 seconds after the end of combat.");
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int processWithDelay(Player player) {
+		return 0;
+	}
+
+	@Override
+	public void stop(Player player) {
+		player.setResting(false);
+		player.setNextAnimation(new Animation(REST_DEFS[index][2]));
+		player.getEmotesManager().setNextEmoteEnd();
+		player.getAppearance().setBAS(-1);
+        if(musicId != -1)
+            player.getMusicsManager().replayMusic();
+	}
+
+}

--- a/src/main/java/com/rs/game/player/content/world/Musician.java
+++ b/src/main/java/com/rs/game/player/content/world/Musician.java
@@ -6,6 +6,7 @@ import com.rs.game.World;
 import com.rs.game.npc.NPC;
 import com.rs.game.player.Player;
 import com.rs.game.player.actions.Rest;
+import com.rs.game.player.actions.RestMusician;
 import com.rs.game.player.content.dialogue.Conversation;
 import com.rs.game.player.content.dialogue.Dialogue;
 import com.rs.game.player.content.dialogue.HeadE;
@@ -17,7 +18,7 @@ import com.rs.plugin.handlers.NPCClickHandler;
 @PluginEventHandler
 public class Musician {
 
-	static Object[] musiciansList = new Object[] { 29, 30, 3463, 3509, 3611, 5442, 8698,8699, 8700, 8701, 8702, 8703, 8704, 8705, 8706, 8707, 8708, 8712, 8713, 8715, 8716, 8717, 8718, 8719, 8720, 8721, 8722, 8723, 14628, 14629, 14640 };
+	static Object[] musiciansList = new Object[] { 29, 30, 3463, 3509, 3611, 5442, 5439, 8698,8699, 8700, 8701, 8702, 8703, 8704, 8705, 8706, 8707, 8708, 8709, 8712, 8713, 8715, 8716, 8717, 8718, 8719, 8720, 8721, 8722, 8723, 14628, 14629, 14640 };
 	
 //	public static NPCClickHandler handleMusicians = new NPCClickHandler("29", "30", "3463", "3509", "3611", "5442", "8698","8699", "8700", "8701", "8702", "8703", "8704", "8705", "8706", "8707", "8708", "8712", "8713", "8715", "8716", "8717", "8718", "8719", "8720", "8721", "8722", "8723", "14628", "14629", "14640") {
 	
@@ -81,12 +82,24 @@ public class Musician {
 	public static NPCClickHandler handleMusicians = new NPCClickHandler(musiciansList) {
 		@Override
 		public void handle(NPCClickEvent e) {
+            Player p = e.getPlayer();
 			switch (e.getOption().toLowerCase()) {
 			case "talk-to":
-					e.getPlayer().startConversation(new MusicianD(e.getPlayer(), e.getNPCId()));
+                e.getNPC().resetDirection();
+                p.startConversation(new MusicianD(p, e.getNPCId()));
 				break;
 			case "listen-to":
-				e.getPlayer().getActionManager().setAction(new Rest());
+                if (p.getEmotesManager().isAnimating()) {
+                    p.sendMessage("You can't rest while perfoming an emote.");
+                    return;
+                }
+                if (p.isLocked()) {
+                    p.sendMessage("You can't rest while perfoming an action.");
+                    return;
+                }
+                p.stopAll();
+                e.getNPC().resetDirection();
+				p.getActionManager().setAction(new RestMusician(e.getNPCId()));
 				break;
 			}
 		}

--- a/src/main/java/com/rs/game/player/content/world/regions/Lumbridge.java
+++ b/src/main/java/com/rs/game/player/content/world/regions/Lumbridge.java
@@ -192,6 +192,20 @@ public class Lumbridge {
 			}
 		}
 	};
+
+    public static ObjectClickHandler handleThievesGuildExitLadder = new ObjectClickHandler(new Object[] { 52308 }) {
+        @Override
+        public void handle(ObjectClickEvent e) {
+            e.getPlayer().useLadder(new WorldTile(3233, 5890, 0));
+        }
+    };
+
+    public static ObjectClickHandler handleThievesGuildEntrance = new ObjectClickHandler(new Object[] { 52309 }) {
+        @Override
+        public void handle(ObjectClickEvent e) {
+            e.getPlayer().useLadder(new WorldTile(4762, 5891, 0));
+        }
+    };
 	
 	public static ObjectClickHandler handleTakeFlour = new ObjectClickHandler(new Object[] { 36880 }) {
 		@Override

--- a/src/main/java/com/rs/game/player/controllers/DragonSlayer_BoatScene.java
+++ b/src/main/java/com/rs/game/player/controllers/DragonSlayer_BoatScene.java
@@ -24,7 +24,7 @@ public class DragonSlayer_BoatScene extends Controller {
     //constants
     int TRAVEL_INTERFACE = 299;
     int BOAT_TO_CRANDOR = 544;
-    int HAPPY_TRAVEL_JINGLE = 172;
+    int HAPPY_TRAVEL_JINGLE = 406; //Custom for this cutscene
     int CAPTAIN_NED = 6084;
     int CABIN_BOY_JENKINS = 6085;
     int ANIM_JENKINS_SHAKE = 2105;
@@ -63,12 +63,13 @@ public class DragonSlayer_BoatScene extends Controller {
 
                 @Override
                 public void run() {
-                    if (tick == 0)  //setup p1
+                    if (tick == 0) {  //setup p1
                         player.getInterfaceManager().setFadingInterface(115);
+                        player.getPackets().sendMusic(HAPPY_TRAVEL_JINGLE);
+                    }
                     if (tick == 3) {
                         player.getInterfaceManager().setFadingInterface(516);
                         player.getPackets().setBlockMinimapState(2);
-                        player.getPackets().sendMusicEffect(HAPPY_TRAVEL_JINGLE);
                         player.getInterfaceManager().sendInterface(TRAVEL_INTERFACE);
                         player.getPackets().setIFHidden(TRAVEL_INTERFACE, 44, false);
                     }
@@ -131,7 +132,7 @@ public class DragonSlayer_BoatScene extends Controller {
                         });
 
                     if(tick == 17) {
-                        player.getPackets().sendMusic(-1, 100, 255);
+                        player.getPackets().sendMusic(360, 100, 255); //Elvarg's theme
                         player.startConversation(new Conversation(player) {
                             {
                                 addSimple("Clouds surround the ship.");

--- a/src/main/java/com/rs/game/player/managers/MusicsManager.java
+++ b/src/main/java/com/rs/game/player/managers/MusicsManager.java
@@ -34,201 +34,201 @@ import com.rs.utils.music.Song;
 @PluginEventHandler
 public final class MusicsManager {
 
-	private static final int[] CONFIG_IDS = new int[] { 20, 21, 22, 23, 24, 25, 298, 311, 346, 414, 464, 598, 662, 721, 906, 1009, 1104, 1136, 1180, 1202, 1381, 1394, 1434, 1596, 1618, 1619, 1620, 1865, 1864, 2246, 2019, -1, 2430, 2559 };
-	private static final int[] PLAY_LIST_CONFIG_IDS = new int[] { 1621, 1622, 1623, 1624, 1625, 1626 };
+    private static final int[] CONFIG_IDS = new int[]{20, 21, 22, 23, 24, 25, 298, 311, 346, 414, 464, 598, 662, 721, 906, 1009, 1104, 1136, 1180, 1202, 1381, 1394, 1434, 1596, 1618, 1619, 1620, 1865, 1864, 2246, 2019, -1, 2430, 2559};
+    private static final int[] PLAY_LIST_CONFIG_IDS = new int[]{1621, 1622, 1623, 1624, 1625, 1626};
 
-	private transient Player player;
-	private transient int playingMusic;
-	private transient long playingMusicDelay;
-	private transient boolean settedMusic;
-	private ArrayList<Integer> unlockedMusics;
-	private ArrayList<Integer> playList;
+    private transient Player player;
+    private transient int playingMusic;
+    private transient long playingMusicDelay;
+    private transient boolean settedMusic;
+    private ArrayList<Integer> unlockedMusics;
+    private ArrayList<Integer> playList;
 
-	private transient boolean playListOn;
-	private transient int nextPlayListMusic;
-	private transient boolean shuffleOn;
+    private transient boolean playListOn;
+    private transient int nextPlayListMusic;
+    private transient boolean shuffleOn;
 
-	public MusicsManager() {
-		unlockedMusics = new ArrayList<Integer>();
-		playList = new ArrayList<Integer>(12);
-		// auto unlocked musics
-		unlockedMusics.add(62);
-		unlockedMusics.add(400);
-		unlockedMusics.add(16);
-		unlockedMusics.add(466);
-		unlockedMusics.add(321);
-		unlockedMusics.add(547);
-		unlockedMusics.add(621);
-		unlockedMusics.add(207);
-		unlockedMusics.add(401);
-		unlockedMusics.add(147);
-		unlockedMusics.add(457);
-		unlockedMusics.add(552);
-		unlockedMusics.add(858);
-	}
-	
-	public static ButtonClickHandler handlePlaylistButtons = new ButtonClickHandler(187) {
-		@Override
-		public void handle(ButtonClickEvent e) {
-			if (e.getComponentId() == 1) {
-				if (e.getPacket() == ClientPacket.IF_OP1)
-					e.getPlayer().getMusicsManager().playAnotherMusic(e.getSlotId() / 2);
-				else if (e.getPacket() == ClientPacket.IF_OP2)
-					e.getPlayer().getMusicsManager().sendHint(e.getSlotId() / 2);
-				else if (e.getPacket() == ClientPacket.IF_OP3)
-					e.getPlayer().getMusicsManager().addToPlayList(e.getSlotId() / 2);
-				else if (e.getPacket() == ClientPacket.IF_OP4)
-					e.getPlayer().getMusicsManager().removeFromPlayList(e.getSlotId() / 2);
-			} else if (e.getComponentId() == 4)
-				e.getPlayer().getMusicsManager().addPlayingMusicToPlayList();
-			else if (e.getComponentId() == 10)
-				e.getPlayer().getMusicsManager().switchPlayListOn();
-			else if (e.getComponentId() == 11)
-				e.getPlayer().getMusicsManager().clearPlayList();
-			else if (e.getComponentId() == 13)
-				e.getPlayer().getMusicsManager().switchShuffleOn();
-		}
-	};
-	
-	public void passMusics(Player p) {
-		for (int musicId : p.getMusicsManager().unlockedMusics) {
-			if (!unlockedMusics.contains(musicId))
-				unlockedMusics.add(musicId);
-		}
-	}
+    public MusicsManager() {
+        unlockedMusics = new ArrayList<Integer>();
+        playList = new ArrayList<Integer>(12);
+        // auto unlocked musics
+        unlockedMusics.add(62);
+        unlockedMusics.add(400);
+        unlockedMusics.add(16);
+        unlockedMusics.add(466);
+        unlockedMusics.add(321);
+        unlockedMusics.add(547);
+        unlockedMusics.add(621);
+        unlockedMusics.add(207);
+        unlockedMusics.add(401);
+        unlockedMusics.add(147);
+        unlockedMusics.add(457);
+        unlockedMusics.add(552);
+        unlockedMusics.add(858);
+    }
 
-	public boolean hasMusic(int id) {
-		return unlockedMusics.contains(id);
-	}
+    public static ButtonClickHandler handlePlaylistButtons = new ButtonClickHandler(187) {
+        @Override
+        public void handle(ButtonClickEvent e) {
+            if (e.getComponentId() == 1) {
+                if (e.getPacket() == ClientPacket.IF_OP1)
+                    e.getPlayer().getMusicsManager().playAnotherMusic(e.getSlotId() / 2);
+                else if (e.getPacket() == ClientPacket.IF_OP2)
+                    e.getPlayer().getMusicsManager().sendHint(e.getSlotId() / 2);
+                else if (e.getPacket() == ClientPacket.IF_OP3)
+                    e.getPlayer().getMusicsManager().addToPlayList(e.getSlotId() / 2);
+                else if (e.getPacket() == ClientPacket.IF_OP4)
+                    e.getPlayer().getMusicsManager().removeFromPlayList(e.getSlotId() / 2);
+            } else if (e.getComponentId() == 4)
+                e.getPlayer().getMusicsManager().addPlayingMusicToPlayList();
+            else if (e.getComponentId() == 10)
+                e.getPlayer().getMusicsManager().switchPlayListOn();
+            else if (e.getComponentId() == 11)
+                e.getPlayer().getMusicsManager().clearPlayList();
+            else if (e.getComponentId() == 13)
+                e.getPlayer().getMusicsManager().switchShuffleOn();
+        }
+    };
 
-	public void setPlayer(Player player) {
-		this.player = player;
-		playingMusic = World.getRegion(player.getRegionId()).getMusicId();
-	}
+    public void passMusics(Player p) {
+        for (int musicId : p.getMusicsManager().unlockedMusics) {
+            if (!unlockedMusics.contains(musicId))
+                unlockedMusics.add(musicId);
+        }
+    }
 
-	public void switchShuffleOn() {
-		if (shuffleOn) {
-			playListOn = false;
-			refreshPlayListConfigs();
-		}
-		shuffleOn = !shuffleOn;
-	}
+    public boolean hasMusic(int id) {
+        return unlockedMusics.contains(id);
+    }
 
-	public void switchPlayListOn() {
-		if (playListOn) {
-			playListOn = false;
-			shuffleOn = false;
-			refreshPlayListConfigs();
-		} else {
-			playListOn = true;
-			nextPlayListMusic = 0;
-			replayMusic();
-		}
-	}
+    public void setPlayer(Player player) {
+        this.player = player;
+        playingMusic = World.getRegion(player.getRegionId()).getMusicId();
+    }
 
-	public void clearPlayList() {
-		if (playList.isEmpty())
-			return;
-		playList.clear();
-		refreshPlayListConfigs();
-	}
+    public void switchShuffleOn() {
+        if (shuffleOn) {
+            playListOn = false;
+            refreshPlayListConfigs();
+        }
+        shuffleOn = !shuffleOn;
+    }
 
-	public void addPlayingMusicToPlayList() {
-		addToPlayList((int) EnumDefinitions.getEnum(1351).getKeyForValue(playingMusic));
-	}
+    public void switchPlayListOn() {
+        if (playListOn) {
+            playListOn = false;
+            shuffleOn = false;
+            refreshPlayListConfigs();
+        } else {
+            playListOn = true;
+            nextPlayListMusic = 0;
+            replayMusic();
+        }
+    }
 
-	public void addToPlayList(int musicIndex) {
-		if (playList.size() == 12)
-			return;
-		int musicId = EnumDefinitions.getEnum(1351).getIntValue(musicIndex);
-		if (musicId != -1 && unlockedMusics.contains(musicId) && !playList.contains(musicId)) {
-			playList.add(musicId);
-			if (playListOn)
-				switchPlayListOn();
-			else
-				refreshPlayListConfigs();
-		}
-	}
+    public void clearPlayList() {
+        if (playList.isEmpty())
+            return;
+        playList.clear();
+        refreshPlayListConfigs();
+    }
 
-	public void removeFromPlayList(int musicIndex) {
-		Integer musicId = EnumDefinitions.getEnum(1351).getIntValue(musicIndex);
-		if (musicId != -1 && unlockedMusics.contains(musicId) && playList.contains(musicId)) {
-			playList.remove(musicId);
-			if (playListOn)
-				switchPlayListOn();
-			else
-				refreshPlayListConfigs();
-		}
-	}
+    public void addPlayingMusicToPlayList() {
+        addToPlayList((int) EnumDefinitions.getEnum(1351).getKeyForValue(playingMusic));
+    }
 
-	public void refreshPlayListConfigs() {
-		int[] configValues = new int[PLAY_LIST_CONFIG_IDS.length];
-		for (int i = 0; i < configValues.length; i++)
-			configValues[i] = -1;
-		for (int i = 0; i < playList.size(); i += 2) {
-			Integer musicId1 = playList.get(i);
-			Integer musicId2 = (i + 1) >= playList.size() ? null : playList.get(i + 1);
-			if (musicId1 == null && musicId2 == null)
-				break;
-			int musicIndex = (int) EnumDefinitions.getEnum(1351).getKeyForValue(musicId1);
-			int configValue;
-			if (musicId2 != null) {
-				int musicIndex2 = (int) EnumDefinitions.getEnum(1351).getKeyForValue(musicId2);
-				configValue = musicIndex | musicIndex2 << 15;
-			} else
-				configValue = musicIndex | -1 << 15;
-			configValues[i / 2] = configValue;
-		}
-		for (int i = 0; i < PLAY_LIST_CONFIG_IDS.length; i++)
-			if (PLAY_LIST_CONFIG_IDS[i] == -1)
-				player.getVars().setVar(PLAY_LIST_CONFIG_IDS[i], configValues[i]);
-	}
+    public void addToPlayList(int musicIndex) {
+        if (playList.size() == 12)
+            return;
+        int musicId = EnumDefinitions.getEnum(1351).getIntValue(musicIndex);
+        if (musicId != -1 && unlockedMusics.contains(musicId) && !playList.contains(musicId)) {
+            playList.add(musicId);
+            if (playListOn)
+                switchPlayListOn();
+            else
+                refreshPlayListConfigs();
+        }
+    }
 
-	public void refreshListConfigs() {
-		int[] configValues = new int[CONFIG_IDS.length];
-		for (int musicId : unlockedMusics) {
-			int musicIndex = (int) EnumDefinitions.getEnum(1351).getKeyForValue(musicId);
-			if (musicIndex == -1)
-				continue;
-			int index = getConfigIndex(musicIndex);
-			if (index >= CONFIG_IDS.length)
-				continue;
-			configValues[index] |= 1 << (musicIndex - (index * 32));
-		}
-		for (int i = 0; i < CONFIG_IDS.length; i++) {
-			if (CONFIG_IDS[i] != -1 && configValues[i] != 0)
-				player.getVars().setVar(CONFIG_IDS[i], configValues[i]);
-		}
-	}
+    public void removeFromPlayList(int musicIndex) {
+        Integer musicId = EnumDefinitions.getEnum(1351).getIntValue(musicIndex);
+        if (musicId != -1 && unlockedMusics.contains(musicId) && playList.contains(musicId)) {
+            playList.remove(musicId);
+            if (playListOn)
+                switchPlayListOn();
+            else
+                refreshPlayListConfigs();
+        }
+    }
 
-	public void addMusic(int musicId) {
-		unlockedMusics.add(musicId);
-		refreshListConfigs();
-	}
-	
-	public int unlockedMusicCount() {
-		return unlockedMusics.size();
-	}
+    public void refreshPlayListConfigs() {
+        int[] configValues = new int[PLAY_LIST_CONFIG_IDS.length];
+        for (int i = 0; i < configValues.length; i++)
+            configValues[i] = -1;
+        for (int i = 0; i < playList.size(); i += 2) {
+            Integer musicId1 = playList.get(i);
+            Integer musicId2 = (i + 1) >= playList.size() ? null : playList.get(i + 1);
+            if (musicId1 == null && musicId2 == null)
+                break;
+            int musicIndex = (int) EnumDefinitions.getEnum(1351).getKeyForValue(musicId1);
+            int configValue;
+            if (musicId2 != null) {
+                int musicIndex2 = (int) EnumDefinitions.getEnum(1351).getKeyForValue(musicId2);
+                configValue = musicIndex | musicIndex2 << 15;
+            } else
+                configValue = musicIndex | -1 << 15;
+            configValues[i / 2] = configValue;
+        }
+        for (int i = 0; i < PLAY_LIST_CONFIG_IDS.length; i++)
+            if (PLAY_LIST_CONFIG_IDS[i] == -1)
+                player.getVars().setVar(PLAY_LIST_CONFIG_IDS[i], configValues[i]);
+    }
 
-	public int getConfigIndex(int musicId) {
-		return (musicId + 1) / 32;
-	}
+    public void refreshListConfigs() {
+        int[] configValues = new int[CONFIG_IDS.length];
+        for (int musicId : unlockedMusics) {
+            int musicIndex = (int) EnumDefinitions.getEnum(1351).getKeyForValue(musicId);
+            if (musicIndex == -1)
+                continue;
+            int index = getConfigIndex(musicIndex);
+            if (index >= CONFIG_IDS.length)
+                continue;
+            configValues[index] |= 1 << (musicIndex - (index * 32));
+        }
+        for (int i = 0; i < CONFIG_IDS.length; i++) {
+            if (CONFIG_IDS[i] != -1 && configValues[i] != 0)
+                player.getVars().setVar(CONFIG_IDS[i], configValues[i]);
+        }
+    }
 
-	public void unlockMusicPlayer() {
-		player.getPackets().setIFRightClickOps(187, 1, 0, CONFIG_IDS.length * 64, 0, 1, 2, 3);
-	}
+    public void addMusic(int musicId) {
+        unlockedMusics.add(musicId);
+        refreshListConfigs();
+    }
 
-	public void init() {
-		// unlock music inter all options
-		if (playingMusic >= 0)
-			playMusic(playingMusic);
-		refreshListConfigs();
-		refreshPlayListConfigs();
-	}
+    public int unlockedMusicCount() {
+        return unlockedMusics.size();
+    }
 
-	public boolean musicEnded() {
-		return playingMusic != -2 && playingMusicDelay + (180000) < System.currentTimeMillis();
-	}
+    public int getConfigIndex(int musicId) {
+        return (musicId + 1) / 32;
+    }
+
+    public void unlockMusicPlayer() {
+        player.getPackets().setIFRightClickOps(187, 1, 0, CONFIG_IDS.length * 64, 0, 1, 2, 3);
+    }
+
+    public void init() {
+        // unlock music inter all options
+        if (playingMusic >= 0)
+            playMusic(playingMusic);
+        refreshListConfigs();
+        refreshPlayListConfigs();
+    }
+
+    public boolean musicEnded() {
+        return playingMusic != -2 && playingMusicDelay + (180000) < System.currentTimeMillis();
+    }
 
     public void replayMusic() {
         if (playListOn && playList.size() > 0) {
@@ -240,7 +240,7 @@ public final class MusicsManager {
                 playingMusic = playList.get(nextPlayListMusic++);
             }
         } else if (unlockedMusics.size() > 0) {// random music
-            if(player.getDungManager().isInsideDungeon())
+            if (player.getDungManager().isInsideDungeon())
                 playingMusic = unlockedMusics.get(Utils.getRandomInclusive(unlockedMusics.size() - 1));
             else
                 do {
@@ -250,19 +250,27 @@ public final class MusicsManager {
         playMusic(playingMusic);
     }
 
-	public void checkMusic(int requestMusicId) {
-		if (playListOn || settedMusic && playingMusicDelay + (180000) >= System.currentTimeMillis())
-			return;
-		settedMusic = false;
-		if (playingMusic != requestMusicId)
-			playMusic(requestMusicId);
-	}
+    /**
+     * Plays music if checked music is not on but includes hints.
+     *
+     * @param requestMusicId
+     */
+    public void checkMusic(int requestMusicId) {
+        if (playListOn || settedMusic && playingMusicDelay + (180000) >= System.currentTimeMillis())
+            return;
+        settedMusic = false;
+        if (playingMusic != requestMusicId)
+            playMusic(requestMusicId);
+    }
 
 	public void forcePlayMusic(int musicId) {
 		settedMusic = true;
 		playMusic(musicId);
 	}
 
+    public boolean isPlaying(int requestMusicId) {
+        return playingMusic == requestMusicId;
+    }
 	public void reset() {
 		settedMusic = false;
 		player.getMusicsManager().checkMusic(World.getRegion(player.getRegionId()).getMusicId());

--- a/src/main/java/com/rs/net/decoders/handlers/NPCHandler.java
+++ b/src/main/java/com/rs/net/decoders/handlers/NPCHandler.java
@@ -419,21 +419,7 @@ public class NPCHandler {
 				}
 				return;
 			}
-			if (npc.getDefinitions().getOption(2).equalsIgnoreCase("listen-to")) {
-				if (player.getEmotesManager().isAnimating()) {
-					player.sendMessage("You can't rest while perfoming an emote.");
-					return;
-				}
-				if (player.isLocked()) {
-					player.sendMessage("You can't rest while perfoming an action.");
-					return;
-				}
-				player.stopAll();
-				npc.resetDirection();
-				player.getActionManager().setAction(new Rest());
-				return;
-			}
-			
+
 			if (npc.getDefinitions().getName(player.getVars()).toLowerCase().equals("void knight")) {
 				CommendationExchange.openExchangeShop(player);
 				return;

--- a/src/main/java/com/rs/utils/music/Genre.java
+++ b/src/main/java/com/rs/utils/music/Genre.java
@@ -1,0 +1,30 @@
+package com.rs.utils.music;
+
+public class Genre {
+    private String genre;
+    private String comment;
+    private int[] regionIds;
+    private int[] songs;
+
+    public String getGenreName() {
+        return genre;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public int[] getRegionIds() {
+        return regionIds;
+    }
+
+    public int[] getSongs() {
+        return songs;
+    }
+
+    public boolean matches(Genre g) {
+        if(g == null || genre == null)
+            return false;
+        return genre.equalsIgnoreCase(g.getGenreName());
+    }
+}

--- a/src/main/java/com/rs/utils/music/Music.java
+++ b/src/main/java/com/rs/utils/music/Music.java
@@ -18,7 +18,9 @@ package com.rs.utils.music;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.google.gson.JsonIOException;
@@ -29,9 +31,11 @@ import com.rs.plugin.annotations.ServerStartupEvent;
 @PluginEventHandler
 public class Music {
 	
-	private static Map<Integer, Song> MUSICS = new HashMap<>();
-	private static Map<Integer, int[]> MUSICS_REGION = new HashMap<>();
-	
+	private static Map<Integer, Song> MUSICS = new HashMap<>();//Full music listing
+	private static Map<Integer, int[]> MUSICS_REGION = new HashMap<>();//hints & unlocks
+
+    private static Map<Integer, Genre> GENRE_REGION = new HashMap<>();//Genre per region, object is a string and int[] songIds pair
+
 	@ServerStartupEvent
 	public static void init() {
 		try {
@@ -51,6 +55,11 @@ public class Music {
 					}
 				}
 			}
+
+            Genre[] genres = (Genre[]) JsonFileManager.loadJsonFile(new File("./data/musicGenre.json"), Genre[].class);
+            for(Genre g : genres)
+                for(int regionId : g.getRegionIds())
+                    GENRE_REGION.put(regionId, g);//none of the values can be empty
 		} catch (JsonIOException | IOException e) {
 			e.printStackTrace();
 		}
@@ -64,4 +73,15 @@ public class Music {
 		return MUSICS.get(musicId);
 	}
 
+    public static Genre getGenre(int regionId) {
+        if(GENRE_REGION.containsKey(regionId)) {
+            Genre g = GENRE_REGION.get(regionId);
+            if(g.getComment().equalsIgnoreCase("isdone"))
+                return g;
+            else
+                return null;
+        }
+        else
+            return null;
+    }
 }


### PR DESCRIPTION
### Music System Prototype Update:
![image](https://user-images.githubusercontent.com/27308928/147589900-c2ca4962-d5b5-4c98-a545-dc57d594c62d.png)
Regions are chosen by hand and added to a JSON from which a list of songs play. Each list of regions and songs is organized as a "genre".

Source: https://runescape.fandom.com/wiki/Music?oldid=5927398
Example:
![image](https://user-images.githubusercontent.com/27308928/147589979-13b7543c-869f-49c8-bc3c-7a5252ef465d.png)

The goal is to have only appropriate songs playing for _most_ regions. This prototype will layer on top of the existing music system. If a region pulls a null Genre from the Genre HashMap it defaults to a random song from unlockedMusics, just like it always had been.
![image](https://user-images.githubusercontent.com/27308928/147590158-e60f6e8f-c38e-40b6-813e-33fa272a8ffa.png)
![image](https://user-images.githubusercontent.com/27308928/147590342-47a9417b-b18d-446c-a123-fdb39e72af02.png)

A final note, to increase immersion and make in-game play like the main game there is a check in World region loading where new music is only played when there is "newly unlocked + notification" music or the Genre is different/null.
![image](https://user-images.githubusercontent.com/27308928/147590922-8c0a4d60-5130-4dcc-972d-6a53cbeb47c6.png)

This means there is no refreshing music for every region inside a genre, this really makes things smooth.

_Lastly..._
There is a potential subsystem I may implement, or just skip, depending on your opinion, about Dungeoneering, whereby the Dungeoneering music is seperated into categories/genres and plays depending on the room-type/floor-type. If you are in a Frozen safe room for example, it adds the safe room song + ambient songs. If you are in a regular room it adds frozen battle room songs + ambient songs but not safe room. Boss songs are restricted to the boss and only played once upon enter. I added the JSON parts to that in musicGenre.json but it can be skipped until the overworld genre is finished.

### Other updates:
-Found & added Dragon Slayer boat music
-Fixed up some musicians
-Added music based on instrument for musicians
-Added a randomized music break between songs(this can be scrapped if you think its a bad thing, Zemo says its not vanilla).
-Filled in a lot of missing song comments in music.json
-Added regions to quest songs(from that region) and missing regions, still have more to do ofc.
-Added access to Thieves Guild in Lumbridge(still no mobs or quests)