### PR TITLE
Add ability to set loot notification threshold at bankers.

### DIFF
--- a/src/main/java/com/rs/game/npc/NPC.java
+++ b/src/main/java/com/rs/game/npc/NPC.java
@@ -677,7 +677,7 @@ public class NPC extends Entity {
 
 		//final WorldTile tile = new WorldTile(getCoordFaceX(size), getCoordFaceY(size), getPlane());
 		int value = item.getDefinitions().getValue() * item.getAmount();
-		if (value > 90000 || item.getDefinitions().name.contains("Scroll box") || item.getDefinitions().name.contains(" defender") || yellDrop(item.getId()))
+		if (value > player.getI("lootbeamThreshold", 90000) || item.getDefinitions().name.contains("Scroll box") || item.getDefinitions().name.contains(" defender") || yellDrop(item.getId()))
 			player.sendMessage("<col=cc0033>You received: "+ item.getAmount() + " " + item.getDefinitions().getName()); //
 		//player.getPackets().sendTileMessage("<shad=000000>"+item.getDefinitions().getName() + " (" + item.getAmount() + ")", tile, 20000, 50, 0xFF0000);
 

--- a/src/main/java/com/rs/game/player/content/world/npcs/Banker.java
+++ b/src/main/java/com/rs/game/player/content/world/npcs/Banker.java
@@ -24,6 +24,7 @@ import com.rs.game.player.content.dialogue.Dialogue;
 import com.rs.game.player.content.dialogue.HeadE;
 import com.rs.game.player.content.dialogue.Options;
 import com.rs.plugin.annotations.PluginEventHandler;
+import com.rs.plugin.events.InputIntegerEvent;
 import com.rs.plugin.events.NPCClickEvent;
 import com.rs.plugin.events.ObjectClickEvent;
 import com.rs.plugin.handlers.NPCClickHandler;
@@ -53,6 +54,19 @@ public class Banker extends Conversation {
 								option("Didn't you used to be called the Bank of Varrock?", new Dialogue()
 										.addNPC(npc.getId(), HeadE.CALM_TALK, "Yes we did, but people kept on coming into our branches outside of Varrock and telling us that our signs were wrong. They acted as if we didn't know what town we were in or something."));
 							}
+						}));
+				option("I'd like to change my theshold for valuable loot notifications.", new Dialogue()
+						.addPlayer(HeadE.HAPPY_TALKING, "I'd like to change my theshold for valuable loot notifications.")
+						.addNPC(npc.getId(), HeadE.HAPPY_TALKING, "Okay, your current threshold is " + player.getI("lootbeamThreshold", 90000) + " GP. What would you like to set it to?")
+						.addNext(() -> { 
+							player.sendInputInteger("What would you like to set it to?", new InputIntegerEvent() {
+								@Override
+								public void run(int amount) {
+									if (amount < 0)
+										return;
+									player.save("lootbeamThreshold", amount);
+								}
+							});
 						}));
 			}
 		});


### PR DESCRIPTION
Looks like the entire banker dialogue was already re-written in the refactor. Just copied over the threshold option.